### PR TITLE
Add the 'readable' attribute to '.reloc'

### DIFF
--- a/binary/hyperion/source/FasmAES-1.0/aes10.asm
+++ b/binary/hyperion/source/FasmAES-1.0/aes10.asm
@@ -54,5 +54,5 @@ section '.edata' export data readable
 	 encAES,'aesEncrypt',\
 	 decAES,'aesDecrypt'
 
-section '.reloc' fixups data discardable
+section '.reloc' fixups data readable discardable
 


### PR DESCRIPTION
After troubleshooting the massive headaches I was running in to, I came upon this solution that actually makes Hyperion run on Windows 8 and up. I actually wrote an enormous issue that I was going to submit just before I decided to try this out, and it worked. The explanation is here in a post by Tomasz Grysztar:

http://board.flatassembler.net/topic.php?p=144941#144941

Without this simple change, Hyperion (i.e. the command-line tool itself) does not run whatsoever on Windows 8.1 (and likely Windows 8, although I can't attest for it).