### PR TITLE
sshtrix: fix compatibility with latest libssh

### DIFF
--- a/cracker/sshtrix/source/Makefile
+++ b/cracker/sshtrix/source/Makefile
@@ -67,7 +67,7 @@ default:
 
 
 sshtrix: $(OBJS)
-	$(CC) -o $@ $^ $(CFLAGS) -pthread -lssh -lssh_threads
+	$(CC) -o $@ $^ $(CFLAGS) -pthread -lssh
 
 
 install:


### PR DESCRIPTION
The distinct `ssh_threads` library is no more, as of `libssh` 0.8.0.

Closes https://github.com/nullsecuritynet/tools/issues/6.